### PR TITLE
make 'deferred' objects into a class

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function Promise(fn) {
 
   this.then = function(onFulfilled, onRejected) {
     return new Promise(function(resolve, reject) {
-      handle({ onFulfilled: onFulfilled, onRejected: onRejected, resolve: resolve, reject: reject })
+      handle(new Handler(onFulfilled, onRejected, resolve, reject))
     })
   }
 
@@ -23,7 +23,7 @@ function Promise(fn) {
     }
     nextTick(function() {
       var cb = state ? deferred.onFulfilled : deferred.onRejected
-      if (typeof cb !== 'function'){
+      if (cb === null) {
         (state ? deferred.resolve : deferred.reject)(value)
         return
       }
@@ -80,4 +80,12 @@ function Promise(fn) {
 
   try { fn(resolve, reject) }
   catch(e) { reject(e) }
+}
+
+
+function Handler(onFulfilled, onRejected, resolve, reject){
+  this.onFulfilled = typeof onFulfilled === 'function' ? onFulfilled : null
+  this.onRejected = typeof onRejected === 'function' ? onRejected : null
+  this.resolve = resolve
+  this.reject = reject
 }


### PR DESCRIPTION
a 20% performance increase (because the VM can make more assumptions about object shape)

```
 ~/code/promise-bench ⮀ node bench.js
old x 129,027 ops/sec ±4.44% (59 runs sampled)
nathan's fix x 156,382 ops/sec ±4.15% (62 runs sampled)
Fastest is nathan's fix
```
