### PR TITLE
Add extensions and documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,24 +12,109 @@
 
     $ npm install promise
 
-  Client:
+## Usage
 
-    $ component install then/promise
-
-## API
-
-  In the example below shows how you can load the promise library (in a way that works on both client and server).  It then demonstrates creating a promise from scratch.  You simply call `new Promise(fn)`.  There is a complete specification for what is returned by this method in [Promises/A+](http://promises-aplus.github.com/promises-spec/).
+  The example below shows how you can load the promise library (in a way that works on both client and server).  It then demonstrates creating a promise from scratch.  You simply call `new Promise(fn)`.  There is a complete specification for what is returned by this method in [Promises/A+](http://promises-aplus.github.com/promises-spec/).
 
 ```javascript
 var Promise = require('promise');
 
 var promise = new Promise(function (resolve, reject) {
-    get('http://www.google.com', function (err, res) {
-      if (err) reject(err);
-      else resolve(res);
-    });
+  get('http://www.google.com', function (err, res) {
+    if (err) reject(err);
+    else resolve(res);
   });
+});
 ```
+
+## API
+
+Before all examples, you will need:
+
+```js
+var Promise = require('promise');
+```
+
+### Promise(resolver)
+
+This creates and returns a new promise.  The `new` keyword before `Promise` is optional.  `resolver` must be a function.  The `resolver` function is passed two arguments:
+
+ 1. `resolve` should be called with a single argument.  If it is called with a non-promise value then the promise is fulfilled with that value.  If it is called with a promise (A) then the returned promise takes on the state of that new promise (A).
+ 2. `reject` should be called with a single argument.  The returned promise will be rejected with that argument.
+
+### Static Functions
+
+  These methods are invoked by calling `Promise.methodName`.
+
+#### Promise.from(value)
+
+Converts values and foreign promises into Promises/A+ promises.  If you pass it a value then it returns a Promise for that value.  If you pass it something that is close to a promise (such as a jQuery attempt at a promise) it returns a Promise that takes on the state of `value` (rejected or fulfilled).
+
+#### Promise.denodeify(fn)
+
+Takes a function which accepts a node style callback and returns a new function that returns a promise instead.
+
+e.g.
+
+```javascript
+var fs = require('fs')
+
+var read = Promise.denodeify(fs.readFile)
+var write = Promise.denodeify(fs.writeFile)
+
+var p = read('foo.json', 'utf8')
+  .then(function (str) {
+    return write('foo.json', JSON.stringify(JSON.parse(str), null, '  '), 'utf8')
+  })
+```
+
+#### Promise.nodeify(fn)
+
+The twin to `denodeify` is useful when you want to export an API that can be used by people who haven't learnt about the brilliance of promises yet.
+
+```javascript
+module.exports = Promise.nodeify(awesomeAPI)
+function awesomeAPI(a, b) {
+  return download(a, b)
+}
+```
+
+If the last argument passed to `module.exports` is a function, then it will be treated like a node.js callback and not parsed on to the child function, otherwise the API will just return a promise.
+
+### Prototype Methods
+
+These methods are invoked on a promise instance by calling `myPromise.methodName`
+
+### Promise#then(onFulfilled, onRejected)
+
+This method follows the [Promises/A+ spec](http://promises-aplus.github.io/promises-spec/).  It explains things very clearly so I recommend you read it.
+
+Either `onFulfilled` or `onRejected` will be called and they will not be called more than once.  They will be passed a single argument and will always be called asynchronously (in the next turn of the event loop).
+
+If the promise is fulfilled then `onFulfilled` is called.  If the promise is rejected then `onRejected` is called.
+
+The call to `.then` also returns a promise.  If the handler that is called returns a promise, the promise returned by `.then` takes on the state of that returned promise.  If the handler that is called returns a value that is not a promise, the promise returned by `.then` will be fulfilled with that value. If the handler that is called throws an exception then the promise returned by `.then` is rejected with that exception.
+
+#### Promise#done(onFulfilled, onRejected)
+
+The same semantics as `.then` except that it does not return a promise and any exceptions are re-thrown so that they can be logged (crashing the applicaiton in non-browser environments)
+
+#### Promise#nodeify(callback)
+
+If `callback` is `null` or `undefined` it just returns `this`.  If `callback` is a function it is called with rejection reason as the first argument and result as the second argument (as per the node.js convention).
+
+This lets you write API functions that look like:
+
+```javascript
+funciton awesomeAPI(foo, bar, callback) {
+  return internalAPI(foo, bar)
+    .then(parseResult)
+    .then(null, retryErrors)
+    .nodeify(callback)
+}
+```
+
+People who use typical node.js style callbacks will be able to just pass a callback and get the expected behavior.  The enlightened people can not pass a callback and will get awesome promises.
 
 ## Extending Promises
 
@@ -83,5 +168,3 @@ Uber.prototype.spread = function (cb) {
 ## License
 
   MIT
-
-![viewcount](https://viewcount.jepso.com/count/then/promise.png)

--- a/core.js
+++ b/core.js
@@ -1,0 +1,97 @@
+var nextTick = require('./lib/next-tick')
+
+module.exports = Promise
+function Promise(fn) {
+  if (!(this instanceof Promise)) return new Promise(fn)
+  if (typeof fn !== 'function') throw new TypeError('not a function')
+  var state = null
+  var delegating = false
+  var value = null
+  var deferreds = []
+  var self = this
+
+  this.then = function(onFulfilled, onRejected) {
+    return new Promise(function(resolve, reject) {
+      handle(new Handler(onFulfilled, onRejected, resolve, reject))
+    })
+  }
+
+  function handle(deferred) {
+    if (state === null) {
+      deferreds.push(deferred)
+      return
+    }
+    nextTick(function() {
+      var cb = state ? deferred.onFulfilled : deferred.onRejected
+      if (cb === null) {
+        (state ? deferred.resolve : deferred.reject)(value)
+        return
+      }
+      var ret
+      try {
+        ret = cb(value)
+      }
+      catch (e) {
+        deferred.reject(e)
+        return
+      }
+      deferred.resolve(ret)
+    })
+  }
+
+  function resolve(newValue) {
+    if (delegating)
+      return
+    resolve_(newValue)
+  }
+
+  function resolve_(newValue) {
+    if (state !== null)
+      return
+    try { //Promise Resolution Procedure: https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure
+      if (newValue === self) throw new TypeError('A promise cannot be resolved with itself.')
+      if (newValue && (typeof newValue === 'object' || typeof newValue === 'function')) {
+        var then = newValue.then
+        if (typeof then === 'function') {
+          delegating = true
+          then.call(newValue, resolve_, reject_)
+          return
+        }
+      }
+      state = true
+      value = newValue
+      finale()
+    } catch (e) { reject_(e) }
+  }
+
+  function reject(newValue) {
+    if (delegating)
+      return
+    reject_(newValue)
+  }
+
+  function reject_(newValue) {
+    if (state !== null)
+      return
+    state = false
+    value = newValue
+    finale()
+  }
+
+  function finale() {
+    for (var i = 0, len = deferreds.length; i < len; i++)
+      handle(deferreds[i])
+    deferreds = null
+  }
+
+  try { fn(resolve, reject) }
+  catch(e) { reject(e) }
+}
+
+
+function Handler(onFulfilled, onRejected, resolve, reject){
+  this.onFulfilled = typeof onFulfilled === 'function' ? onFulfilled : null
+  this.onRejected = typeof onRejected === 'function' ? onRejected : null
+  this.resolve = resolve
+  this.reject = reject
+}

--- a/lib/next-tick.js
+++ b/lib/next-tick.js
@@ -1,0 +1,7 @@
+if (typeof setImmediate === 'function') { // IE >= 10 & node.js >= 0.10
+  module.exports = function(fn){ setImmediate(fn) }
+} else if (typeof process !== 'undefined' && process && typeof process.nextTick === 'function') { // node.js before 0.10
+  module.exports = function(fn){ process.nextTick(fn) }
+} else {
+  module.exports = function(fn){ setTimeout(fn, 0) }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha -R spec --timeout 200 --slow 99999",
-    "test-resolve": "mocha test/resolver-tests.js -R spec --timeout 200 --slow 999999"
+    "test-resolve": "mocha test/resolver-tests.js -R spec --timeout 200 --slow 999999",
+    "test-extensions": "mocha test/extensions-tests.js -R spec --timeout 200 --slow 999999"
   },
   "repository": {
     "type": "git",

--- a/test/extensions-tests.js
+++ b/test/extensions-tests.js
@@ -1,0 +1,170 @@
+var assert = require('better-assert');
+var Promise = require('../');
+var sentinel = {};
+var promise = new Promise(function (resolve) {
+  resolve(sentinel);
+});
+var thenable = {then: function (fullfilled, rejected) { fullfilled(sentinel) }}
+var thenableRejected = {then: function (fullfilled, rejected) { rejected(sentinel) }}
+
+describe('extensions', function () {
+  describe('Promise.from', function () {
+    describe('if passed a true promise', function () {
+      it('returns it directly', function () {
+        assert(promise === Promise.from(promise))
+      })
+    })
+    describe('if passed a thenable', function () {
+      it('assimilates it', function (done) {
+        var i = 2
+        var promise = Promise.from(thenable)
+        var promiseRejected = Promise.from(thenableRejected)
+        assert(promise instanceof Promise)
+        assert(promiseRejected instanceof Promise)
+        promise.then(function (res) {
+          assert(res === sentinel)
+          if (0 === --i) done()
+        })
+        .then(null, done)
+        promiseRejected.then(null, function (err) {
+          assert(err === sentinel)
+          if (0 === --i) done()
+        })
+        .then(null, done)
+      })
+    })
+    describe('if passed a value', function () {
+      it('wraps it in a promise', function (done) {
+        var promise = Promise.from(sentinel)
+          .then(function (res) {
+            assert(res === sentinel)
+            done()
+          })
+        assert(promise instanceof Promise)
+      })
+    })
+  })
+  describe('Promise.denodeify(fn)', function () {
+    it('returns a function that uses promises instead of callbacks', function (done) {
+      function wrap(val, key, callback) {
+        return callback(null, {val: val, key: key})
+      }
+      var pwrap = Promise.denodeify(wrap)
+      pwrap(sentinel, 'foo')
+        .then(function (wrapper) {
+          assert(wrapper.val === sentinel)
+          assert(wrapper.key === 'foo')
+          done()
+        })
+    })
+    it('converts callback error arguments into rejection', function (done) {
+      function fail(val, key, callback) {
+        return callback(sentinel)
+      }
+      var pfail = Promise.denodeify(fail)
+      pfail(promise, 'foo')
+        .then(null, function (err) {
+          assert(err === sentinel)
+          done()
+        })
+    })
+  })
+  describe('Promise.nodeify(fn)', function () {
+    it('converts a promise returning function into a callback function', function (done) {
+      var add = Promise.nodeify(function (a, b) {
+        return Promise.from(a)
+          .then(function (a) {
+            return a + b
+          })
+      })
+      add(1, 2, function (err, res) {
+        if (err) return done(err)
+        assert(res === 3)
+        return done()
+      })
+    })
+    it('converts rejected promises into the first argument of the callback', function (done) {
+      var add = Promise.nodeify(function (a, b) {
+        return Promise.from(a)
+          .then(function (a) {
+            throw sentinel
+          })
+      })
+      var add2 = Promise.nodeify(function (a, b) {
+        throw sentinel
+      })
+      add(1, 2, function (err, res) {
+        assert(err === sentinel)
+        add2(1, 2, function (err, res){
+          assert(err === sentinel)
+          done()
+        })
+      })
+    })
+    it('passes through when no callback is provided', function (done) {
+      var add = Promise.nodeify(function (a, b) {
+        return Promise.from(a)
+          .then(function (a) {
+            return a + b
+          })
+      })
+      add(1, 2)
+        .then(function (res) {
+          assert(res === 3)
+          done()
+        })
+    })
+  })
+
+  describe('promise.done(onFulfilled, onRejected)', function () {
+    it.skip('behaves like then except for not returning anything', function () {
+      //todo
+    })
+    it.skip('rethrows unhandled rejections', function () {
+      //todo
+    })
+  })
+  describe('promise.nodeify(callback)', function () {
+    it('converts a promise returning function into a callback function', function (done) {
+      function add(a, b, callback) {
+        return Promise.from(a)
+          .then(function (a) {
+            return a + b
+          })
+          .nodeify(callback)
+      }
+      add(1, 2, function (err, res) {
+        if (err) return done(err)
+        assert(res === 3)
+        return done()
+      })
+    })
+    it('converts rejected promises into the first argument of the callback', function (done) {
+      function add(a, b, callback) {
+        return Promise.from(a)
+          .then(function (a) {
+            throw sentinel
+          })
+          .nodeify(callback)
+      }
+      add(1, 2, function (err, res) {
+        assert(err === sentinel)
+        done()
+      })
+    })
+    it('passes through when no callback is provided', function (done) {
+      function add(a, b, callback) {
+        return Promise.from(a)
+          .then(function (a) {
+            return a + b
+          })
+          .nodeify(callback)
+      }
+      add(1, 2)
+        .then(function (res) {
+          assert(res === 3)
+          done()
+        })
+    })
+  })
+})


### PR DESCRIPTION
I think it's time we thought about some small extensions being built into this library.  As it stands it's not really very useful.

I've kept the API separate by having a `./core.js` file that contains the same minimal promise implementation that it always did.  The index.js then just extends that Promise object.
## Error Reporting

There needs to be something better for error reporting.  `promise.then` results in errors being swallowed, so I think we should add `promise.done`.  Virtually all the popular Promises/A+ libraries have promises that work the same way.
## Convenience

I need a way to assimilate promises from broken libraries or create a promise for a value all the time, so I added `Promise.assimilate`.
## Interoperability

Sadly all the node.js APIs are still not compatible with promises, so `Promise.denodeify` is needed to convert those callback functions into functions that return promises.

When I'm creating libraries that aren't directly for manipulating promises I want them to be usable by people who are only using callbacks, otherwise they won't gain popularity.  With this in mind I added `promise.nodeify` and `Promise.nodeify`.
## Ease of Use

It can be useful to make functions that just resolve all their arguments so that you can pass promises around as first class values whenever you like.  To do this, I created `Promise.promisify`.  It's used internally by `Promise.nodeify` and `Promise.denodeify` to make those APIs even more useful.  This is the one I'm least sure about because:

a) It's a relatively large amount of code that would be significantly neater if I could depend on `all`
b) It's not something I've actively used in real world applications.  All the other extensions listed here are things I've used hundreds of times and have proved to be totally indispensable.
