### PR TITLE
Support passing `argumentCount` denodeify

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,11 +57,15 @@ Promise.from = function (value) {
 
   return new ValuePromise(value)
 }
-Promise.denodeify = function (fn) {
+Promise.denodeify = function (fn, argumentCount) {
+  argumentCount = argumentCount || Infinity
   return function () {
     var self = this
     var args = Array.prototype.slice.call(arguments)
     return new Promise(function (resolve, reject) {
+      while (args.length && args.length > argumentCount) {
+        args.pop()
+      }
       args.push(function (err, res) {
         if (err) reject(err)
         else resolve(res)

--- a/test/extensions-tests.js
+++ b/test/extensions-tests.js
@@ -57,7 +57,7 @@ describe('extensions', function () {
       })
     })
   })
-  describe('Promise.denodeify(fn)', function () {
+  describe('Promise.denodeify(fn, [argumentCount])', function () {
     it('returns a function that uses promises instead of callbacks', function (done) {
       function wrap(val, key, callback) {
         return callback(null, {val: val, key: key})
@@ -78,6 +78,18 @@ describe('extensions', function () {
       pfail(promise, 'foo')
         .then(null, function (err) {
           assert(err === sentinel)
+          done()
+        })
+    })
+    it('with an argumentCount it ignores extra arguments', function (done) {
+      function wrap(val, key, callback) {
+        return callback(null, {val: val, key: key})
+      }
+      var pwrap = Promise.denodeify(wrap, 2)
+      pwrap(sentinel, 'foo', 'wtf')
+        .then(function (wrapper) {
+          assert(wrapper.val === sentinel)
+          assert(wrapper.key === 'foo')
           done()
         })
     })


### PR DESCRIPTION
This lets you run code like:

``` javascript
var stat = Promise.denodeify(fs.stat, 1);

var stats = Promise.all(['file1.txt', 'file2.txt', 'directory'].map(stat));
```

which would currently fail as the `callback` gets passed as the wrong argument.
