### PR TITLE
Added example of nested promises with a single error handler

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,17 +104,22 @@ var doAsync = function(nbr) {
     return promise;
 };
 
+var handleSuccess = function(result) {
+    console.log('Success: ' + result);
+};
+
+var handleError = function(error) {
+    console.log('Error: ' + error);
+};
+
 doAsync(0).then(doAsync).
     then(doAsync).
     then(doAsync).
     then(doAsync).
     then(doAsync).
     then(doAsync).
-    then(function(result) {
-    console.log('Success: ' + result);
-}, function(error) {
-    console.log('Error: ' + error);
-});
+    then(doAsync).
+    then(handleSuccess, handleError);
 ```
 
 #### Promise.denodeify(fn)


### PR DESCRIPTION
I find that I often nest several actions and by having just one error handler the code is much more readable. Since the Readme.md did not have an example I was not sure this Promises/A+ implementation supported that functionality. I created this sample code and tested it with a current stable release of Node to confirm it works as expected so the documentation could be updated to include this sample.
