### PR TITLE
Allows an inheriting constructor to return itself when calling .then

### DIFF
--- a/core.js
+++ b/core.js
@@ -12,7 +12,7 @@ function Promise(fn) {
   var self = this
 
   this.then = function(onFulfilled, onRejected) {
-    return new Promise(function(resolve, reject) {
+    return new self.constructor(function(resolve, reject) {
       handle(new Handler(onFulfilled, onRejected, resolve, reject))
     })
   }

--- a/test/extensions-tests.js
+++ b/test/extensions-tests.js
@@ -372,4 +372,20 @@ describe('extensions', function () {
         })
     })
   })
+
+  describe('inheritance', function () {
+    it('allows its prototype methods to act upon foreign constructors', function () {
+      function Awesome(fn) {
+        if (!(this instanceof Awesome)) return new Awesome(fn)
+        Promise.call(this, fn)
+      }
+      Awesome.prototype = Object.create(Promise.prototype)
+      Awesome.prototype.constructor = Awesome
+
+      var awesome = new Awesome(function () {})
+
+      assert(awesome.constructor === Awesome)
+      assert(awesome.then(function () {}).constructor === Awesome)
+    })
+  })
 })


### PR DESCRIPTION
given

``` js
function Awesome(fn) {
  if (!(this instanceof Awesome)) return new Awesome(fn)
  Promise.call(this, fn)
}
Awesome.prototype = Object.create(Promise.prototype)
Awesome.prototype.constructor = Awesome
```

previously...

``` js
var awesome = new Awesome(function () {})
awesome.then(function () {})
// => Promise
```

now...

``` js
var awesome = new Awesome(function () {})
awesome.then(function () {})
// => Awesome
```
