### PR TITLE
Promise.prototype.nodeify callback safety

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ Promise.prototype.done = function (onFulfilled, onRejected) {
 }
 
 Promise.prototype.nodeify = function (callback) {
-  if (!(typeof callback == 'function')) return this
+  if (typeof callback != 'function') return this
 
   this.then(function (value) {
     asap(function () {


### PR DESCRIPTION
Checks that a callback passed to Promise.prototype.nodeify is callable before attempting to call
