### PR TITLE
"catch" is a reserved word in ES3

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ Promise.prototype.nodeify = function (callback) {
   })
 }
 
-Promise.prototype.catch = function (onRejected) {
+Promise.prototype['catch'] = function (onRejected) {
   return this.then(null, onRejected);
 }
 
@@ -170,3 +170,4 @@ Promise.race = function (values) {
     })
   });
 }
+

--- a/test/extensions-tests.js
+++ b/test/extensions-tests.js
@@ -56,12 +56,12 @@ describe('extensions', function () {
             assert(res === sentinel)
             if (0 === --i) done()
           })
-          .catch(done)
-          promiseRejected.catch(function (err) {
+          ['catch'](done)
+          promiseRejected['catch'](function (err) {
             assert(err === sentinel)
             if (0 === --i) done()
           })
-          .catch(done)
+          ['catch'](done)
         })
       })
     })


### PR DESCRIPTION
I know, it looks ugly, but this way, `promise` will not throw a syntax error in ES3 browsers.
