### PR TITLE
Added #catch(onRejected) method

### DIFF
--- a/core.js
+++ b/core.js
@@ -17,6 +17,10 @@ function Promise(fn) {
     })
   }
 
+  this.catch = function(onRejected) {
+    return this.then(undefined, onRejected);
+  }
+
   function handle(deferred) {
     if (state === null) {
       deferreds.push(deferred)


### PR DESCRIPTION
As per ES6 Draft

25.4.5.1 Promise.prototype.catch ( onRejected )
When the catch method is called with argument onRejected the following steps are taken:
1. Let promise be the this value.
2. Return Invoke(promise, "then", (undefined, onRejected)).
