### PR TITLE
Avoids an unnecessary Object.create call

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function ValuePromise(value) {
     })
   }
 }
-ValuePromise.prototype = Object.create(Promise.prototype)
+ValuePromise.prototype = Promise.prototype
 
 var TRUE = new ValuePromise(true)
 var FALSE = new ValuePromise(false)


### PR DESCRIPTION
The inheritance pattern here shouldn't need an `Object.create`, as its prototype isn't being modified. ValuePromise simply sets its own `then` property on initialization, which has no risk of clobbering anything on the prototype.

Bonus: ie8 likes it :tada: 
