### PR TITLE
Readme update: replace deprecated .from() with .resolve()

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,14 +74,14 @@ Converts values and foreign promises into Promises/A+ promises.  If you pass it 
 Returns a promise for an array.  If it is called with a single argument that `Array.isArray` then this returns a promise for a copy of that array with any promises replaced by their fulfilled values.  Otherwise it returns a promise for an array that conatins its arguments, except with promises replaced by their resolution values.  e.g.
 
 ```js
-Promise.all([Promise.from('a'), 'b', Promise.from('c')])
+Promise.all([Promise.resolve('a'), 'b', Promise.resolve('c')])
   .then(function (res) {
     assert(res[0] === 'a')
     assert(res[1] === 'b')
     assert(res[2] === 'c')
   })
 
-Promise.all(Promise.from('a'), 'b', Promise.from('c'))
+Promise.all(Promise.resolve('a'), 'b', Promise.resolve('c'))
   .then(function (res) {
     assert(res[0] === 'a')
     assert(res[1] === 'b')


### PR DESCRIPTION
This PR changes readme so that in Promise.all code snippet Promise.resolve is called instead of Promise.from.

Promise.from is deprecated as metioned in readme around Promise.resolve. It even looks to me that .from is no longer presnet in ver. 6.0.1.
