### PR TITLE
switch to asap@2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "mocha": "*"
   },
   "dependencies": {
-    "asap": "~2.0.0"
+    "asap": "~2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "mocha": "*"
   },
   "dependencies": {
-    "asap": "~1.0.0"
+    "asap": "~2.0.0"
   }
 }


### PR DESCRIPTION
fix #61

Do *not* merge as-is. This breaks Browserify badly until https://github.com/kriskowal/asap/commit/588bb88bf9dfb4a1cb4a612f74486be476cad744 is published to npm.
This'll probably have to be changed to `@2.0.1`.