### PR TITLE
Changing denodeify to support functions that return promises

### DIFF
--- a/lib/node-extensions.js
+++ b/lib/node-extensions.js
@@ -22,7 +22,10 @@ Promise.denodeify = function (fn, argumentCount) {
         if (err) reject(err)
         else resolve(res)
       })
-      fn.apply(self, args)
+      var res = fn.apply(self, args)
+      if (res && res.then) {
+        resolve(res)
+      }
     })
   }
 }

--- a/lib/node-extensions.js
+++ b/lib/node-extensions.js
@@ -23,7 +23,7 @@ Promise.denodeify = function (fn, argumentCount) {
         else resolve(res)
       })
       var res = fn.apply(self, args)
-      if (res && res.then) {
+      if (res && (typeof res === 'object' || typeof res === 'function') && typeof res.then === 'function') {
         resolve(res)
       }
     })

--- a/test/extensions-tests.js
+++ b/test/extensions-tests.js
@@ -55,6 +55,20 @@ describe('extensions', function () {
           done()
         })
     })
+    it('resolves correctly when the wrapped function returns a promise anyway', function (done) {
+      function wrap(val, key, callback) {
+        return new Promise(function(resolve, reject) {
+          resolve({val: val, key: key})
+        })
+      }
+      var pwrap = Promise.denodeify(wrap)
+      pwrap(sentinel, 'foo')
+        .then(function (wrapper) {
+          assert(wrapper.val === sentinel)
+          assert(wrapper.key === 'foo')
+          done()
+        })
+    })
   })
   describe('Promise.nodeify(fn)', function () {
     it('converts a promise returning function into a callback function', function (done) {


### PR DESCRIPTION
I'm writing a library that can be extended by consumers who want to overwrite some of the functions.

Internally, I am using promises.  However, I would like consumers to have the option of writing implementing functions that either call a callback, or return a promise, as they prefer.

Promise.denodeify is nearly perfect, except that it forces all implementers to use a callback, removing the option of returning a promise.

This pull request changes denodeify so that if the wrapped function returns a thenable object, that object is used to resolve the promise.