### PR TITLE
Fix Promise#all with multiple arguments, broken in 0498f7c4

### DIFF
--- a/lib/es6-extensions.js
+++ b/lib/es6-extensions.js
@@ -59,7 +59,9 @@ Promise.resolve = function (value) {
 }
 
 Promise.all = function (arr) {
-  var args = Array.prototype.slice.call(arr)
+  var args = arr;
+  if (arguments.length !== 1 || !Array.isArray(arr))
+     args = Array.prototype.slice.call(arguments)
 
   return new Promise(function (resolve, reject) {
     if (args.length === 0) return resolve([])

--- a/test/extensions-tests.js
+++ b/test/extensions-tests.js
@@ -196,6 +196,19 @@ describe('extensions', function () {
         })
       })
     })
+    describe('a list of values', function () {
+      it('resolve to an array of values', function (done) {
+        var res = Promise.all(A, b, C)
+        assert(res instanceof Promise)
+        res.then(function (res) {
+          assert(Array.isArray(res))
+          assert(res[0] === a)
+          assert(res[1] === b)
+          assert(res[2] === c)
+        })
+        .nodeify(done)
+      })
+    })
   })
 
   describe('promise.done(onFulfilled, onRejected)', function () {


### PR DESCRIPTION
Note that the spec seems to not have this functionality, thus, perhaps, the removal was purposeful.
If it was, see #71.