### PR TITLE
nodeify now works with thenables not just then/promise promises

### DIFF
--- a/lib/node-extensions.js
+++ b/lib/node-extensions.js
@@ -35,7 +35,8 @@ Promise.nodeify = function (fn) {
     var callback = typeof args[args.length - 1] === 'function' ? args.pop() : null
     var ctx = this
     try {
-      return fn.apply(this, arguments).nodeify(callback, ctx)
+      var thenable = fn.apply(this, arguments)
+      return Promise.resolve(thenable).nodeify(callback, ctx)
     } catch (ex) {
       if (callback === null || typeof callback == 'undefined') {
         return new Promise(function (resolve, reject) { reject(ex) })

--- a/test/extensions-tests.js
+++ b/test/extensions-tests.js
@@ -129,6 +129,16 @@ describe('extensions', function () {
         done()
       })
     })
+    it('works with thenables', function (done) {
+      var thenableNodeified = Promise.nodeify(function () {
+        return thenable;
+      })
+      thenableNodeified(function (err, res) {
+        if (err) return done(err)
+        assert(res === sentinel)
+        return done()
+      })
+    })
   })
   describe('Promise.all(...)', function () {
     describe('an array', function () {


### PR DESCRIPTION
Found this when using async/await feature with babel and got `Object #<Object> has no method 'nodeify'`