### PR TITLE
Optimisations

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -35,12 +35,12 @@ function Promise(fn) {
       deferreds.push(deferred)
       return
     }
+    var cb = state ? deferred.onFulfilled : deferred.onRejected
+    if (cb === null) {
+      (state ? deferred.resolve : deferred.reject)(value)
+      return
+    }
     asap(function() {
-      var cb = state ? deferred.onFulfilled : deferred.onRejected
-      if (cb === null) {
-        (state ? deferred.resolve : deferred.reject)(value)
-        return
-      }
       var ret
       try {
         ret = cb(value)

--- a/lib/es6-extensions.js
+++ b/lib/es6-extensions.js
@@ -65,20 +65,16 @@ Promise.all = function (arr) {
     if (args.length === 0) return resolve([])
     var remaining = args.length
     function res(i, val) {
-      try {
-        if (val && (typeof val === 'object' || typeof val === 'function')) {
-          var then = val.then
-          if (typeof then === 'function') {
-            then.call(val, function (val) { res(i, val) }, reject)
-            return
-          }
+      if (val && (typeof val === 'object' || typeof val === 'function')) {
+        var then = val.then
+        if (typeof then === 'function') {
+          then.call(val, function (val) { res(i, val) }, reject)
+          return
         }
-        args[i] = val
-        if (--remaining === 0) {
-          resolve(args);
-        }
-      } catch (ex) {
-        reject(ex)
+      }
+      args[i] = val
+      if (--remaining === 0) {
+        resolve(args);
       }
     }
     for (var i = 0; i < args.length; i++) {


### PR DESCRIPTION
I did a little benchmarking and I believe these improvements together result in somewhere between 2% and 5% speed up.  they don't have any other observable impact, so I think they're a net win (albeit a small one)

Benchmark on master:

```
bluebird x 84.93 ops/sec ±1.97% (81 runs sampled)
es6-promises x 54.57 ops/sec ±2.42% (68 runs sampled)
legendary x 53.10 ops/sec ±2.87% (66 runs sampled)
lie x 85.25 ops/sec ±2.28% (71 runs sampled)
native x 72.57 ops/sec ±2.17% (75 runs sampled)
native-promise-only x 72.93 ops/sec ±1.46% (71 runs sampled)
promise x 62.81 ops/sec ±3.93% (73 runs sampled)
q x 31.55 ops/sec ±2.87% (58 runs sampled)
vow x 81.39 ops/sec ±1.02% (78 runs sampled)
```
Benchmark using this branch:

```
bluebird x 83.81 ops/sec ±2.45% (81 runs sampled)
es6-promises x 53.03 ops/sec ±2.73% (66 runs sampled)
legendary x 53.76 ops/sec ±2.93% (67 runs sampled)
lie x 82.69 ops/sec ±2.10% (70 runs sampled)
native x 73.44 ops/sec ±1.25% (72 runs sampled)
native-promise-only x 71.81 ops/sec ±1.51% (70 runs sampled)
promise x 65.19 ops/sec ±2.90% (69 runs sampled)
q x 31.61 ops/sec ±2.63% (60 runs sampled)
vow x 79.01 ops/sec ±2.84% (76 runs sampled)
```

These figures are still sadly prety bad for us.