### PR TITLE
Add builds for domains and setImmedaite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ components
 build
 node_modules
 /lib
+/domains
+/setimmediate

--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ Note that the [es5-shim](https://github.com/es-shims/es5-shim) must be loaded be
 
 ## Usage
 
-The example below shows how you can load the promise library (in a way that works on both client and server).  It then demonstrates creating a promise from scratch.  You simply call `new Promise(fn)`.  There is a complete specification for what is returned by this method in [Promises/A+](http://promises-aplus.github.com/promises-spec/).
+The example below shows how you can load the promise library (in a way that works on both client and server using node or browserify).  It then demonstrates creating a promise from scratch.  You simply call `new Promise(fn)`.  There is a complete specification for what is returned by this method in [Promises/A+](http://promises-aplus.github.com/promises-spec/).
 
 ```javascript
 var Promise = require('promise');
@@ -54,6 +54,26 @@ var promise = new Promise(function (resolve, reject) {
     else resolve(res);
   });
 });
+```
+
+If you need [domains](https://iojs.org/api/domain.html) support, you should instead use:
+
+```js
+var Promise = require('promise/domains');
+```
+
+If you are in an environment that implements `setImmediate` and don't want the optimisations provided by asap, you can use:
+
+```js
+var Promise = require('promise/setimmediate');
+```
+
+If you only want part of the features, e.g. just a pure ES6 polyfill:
+
+```js
+var Promise = require('promise/lib/es6-extensions');
+// or require('promise/domains/es6-extensions');
+// or require('promise/setimmediate/es6-extensions');
 ```
 
 ## API

--- a/build.js
+++ b/build.js
@@ -48,3 +48,22 @@ fs.readdirSync(__dirname + '/src').forEach(function (filename) {
   var out = fixup(src);
   fs.writeFileSync(__dirname + '/lib/' + filename, out);
 });
+
+rimraf.sync(__dirname + '/domains/');
+fs.mkdirSync(__dirname + '/domains/');
+fs.readdirSync(__dirname + '/src').forEach(function (filename) {
+  var src = fs.readFileSync(__dirname + '/src/' + filename, 'utf8');
+  var out = fixup(src);
+  out = out.replace(/require\(\'asap\/raw\'\)/g, "require('asap')");
+  fs.writeFileSync(__dirname + '/domains/' + filename, out);
+});
+
+rimraf.sync(__dirname + '/setimmediate/');
+fs.mkdirSync(__dirname + '/setimmediate/');
+fs.readdirSync(__dirname + '/src').forEach(function (filename) {
+  var src = fs.readFileSync(__dirname + '/src/' + filename, 'utf8');
+  var out = fixup(src);
+  out = out.replace(/var asap \= require\(\'([a-z\/]+)\'\)/g, '');
+  out = out.replace(/asap/g, "setImmediate");
+  fs.writeFileSync(__dirname + '/setimmediate/' + filename, out);
+});

--- a/index.js
+++ b/index.js
@@ -1,7 +1,3 @@
 'use strict';
 
-module.exports = require('./lib/core.js')
-require('./lib/done.js')
-require('./lib/finally.js')
-require('./lib/es6-extensions.js')
-require('./lib/node-extensions.js')
+module.exports = require('./lib')

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Bare bones Promises/A+ implementation",
   "main": "index.js",
   "scripts": {
+    "prepublish": "node build",
     "pretest": "node build",
     "pretest-resolve": "node build",
     "pretest-extensions": "node build",

--- a/src/done.js
+++ b/src/done.js
@@ -1,14 +1,13 @@
 'use strict';
 
 var Promise = require('./core.js')
-var asap = require('asap')
 
 module.exports = Promise
 Promise.prototype.done = function (onFulfilled, onRejected) {
   var self = arguments.length ? this.then.apply(this, arguments) : this
   self.then(null, function (err) {
-    asap(function () {
+    setTimeout(function () {
       throw err
-    })
+    }, 0)
   })
 }

--- a/src/es6-extensions.js
+++ b/src/es6-extensions.js
@@ -3,7 +3,7 @@
 //This file contains the ES6 extensions to the core Promises/A+ API
 
 var Promise = require('./core.js')
-var asap = require('asap')
+var asap = require('asap/raw')
 
 module.exports = Promise
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = require('./core.js')
+require('./done.js')
+require('./finally.js')
+require('./es6-extensions.js')
+require('./node-extensions.js')


### PR DESCRIPTION
This adds two additional builds, one for environments where there is an
extremely efficient setImmedaite implementation and asap is just
unnecessary overhead and another for environments where support for
domains is essential.