### PR TITLE
Support misbehaving promises in Promise.all

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -64,6 +64,7 @@ function Promise(fn) {
   if (fn === noop) return;
   doResolve(fn, this);
 }
+Promise._noop = noop;
 
 Promise.prototype.then = function(onFulfilled, onRejected) {
   if (this.constructor !== Promise) {


### PR DESCRIPTION
We currently break when `Promise.all` is given a Promise that "fulfills" twice.  This is not an issue with Promises/A+ compliant implementations, but it is still probably worth fixing.

I also took this opportunity to optimise our approach to `Promise.all` on promises that are already resolved and simplify how we do value promises in `Promise.resolve`.