### PR TITLE
Avoid unnecessary loop in Promise.denodeify

### DIFF
--- a/src/node-extensions.js
+++ b/src/node-extensions.js
@@ -14,11 +14,9 @@ Promise.denodeify = function (fn, argumentCount) {
   argumentCount = argumentCount || Infinity;
   return function () {
     var self = this;
-    var args = Array.prototype.slice.call(arguments);
+    var args = Array.prototype.slice.call(arguments, 0,
+        argumentCount > 0 ? argumentCount : 0);
     return new Promise(function (resolve, reject) {
-      while (args.length && args.length > argumentCount) {
-        args.pop();
-      }
       args.push(function (err, res) {
         if (err) reject(err);
         else resolve(res);


### PR DESCRIPTION
There's no need to call `Array.prototype.pop()` in a loop when `Array.prototype.slice()` is already being called at the beginning.

The `argumentCount > 0 ? argumentCount : 0` would be unnecessary but is there to preserve backwards compatibility.