### PR TITLE
Sync inspection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,3 +5,4 @@ require('./done.js');
 require('./finally.js');
 require('./es6-extensions.js');
 require('./node-extensions.js');
+require('./synchronous.js');

--- a/src/synchronous.js
+++ b/src/synchronous.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var Promise = require('./core.js');
+
+module.exports = Promise;
+Promise.enableSynchronous = function () {
+  Promise.prototype.isPending = function() {
+    return this._state == 0;
+  };
+
+  Promise.prototype.isFulfilled = function() {
+    return this._state == 1;
+  };
+
+  Promise.prototype.isRejected = function() {
+    return this._state == 2;
+  };
+
+  Promise.prototype.value = function () {
+    if (!this.isFulfilled()) {
+      throw new Error('Cannot get a value of an unfulfilled promise.');
+    }
+
+    return this._value;
+  };
+
+  Promise.prototype.reason = function () {
+    if (!this.isRejected()) {
+      throw new Error('Cannot get a rejection reason of a non-rejected promise.');
+    }
+
+    return this._value;
+  };
+};

--- a/src/synchronous.js
+++ b/src/synchronous.js
@@ -16,7 +16,7 @@ Promise.enableSynchronous = function () {
     return this._state == 2;
   };
 
-  Promise.prototype.value = function () {
+  Promise.prototype.getValue = function () {
     if (!this.isFulfilled()) {
       throw new Error('Cannot get a value of an unfulfilled promise.');
     }
@@ -24,11 +24,19 @@ Promise.enableSynchronous = function () {
     return this._value;
   };
 
-  Promise.prototype.reason = function () {
+  Promise.prototype.getReason = function () {
     if (!this.isRejected()) {
       throw new Error('Cannot get a rejection reason of a non-rejected promise.');
     }
 
     return this._value;
   };
+};
+
+Promise.disableSynchronous = function() {
+  Promise.prototype.isPending = undefined;
+  Promise.prototype.isFulfilled = undefined;
+  Promise.prototype.isRejected = undefined;
+  Promise.prototype.getValue = undefined;
+  Promise.prototype.getReason = undefined;
 };

--- a/test/synchronous-inspection-tests.js
+++ b/test/synchronous-inspection-tests.js
@@ -70,7 +70,7 @@ describe('synchronous-inspection-tests', function () {
     setTimeout(function () {
       assert(fulfilledPromise.isFulfilled());
       assert(!fulfilledPromise.isRejected());
-      assert(fulfilledPromise.value());
+      assert(fulfilledPromise.getValue());
       assert(!fulfilledPromise.isPending());
     }, 30);
   });
@@ -102,7 +102,7 @@ describe('synchronous-inspection-tests', function () {
     setTimeout(function () {
       assert(!fulfilledPromise.isFulfilled());
       assert(fulfilledPromise.isRejected());
-      assert(!fulfilledPromise.reason());
+      assert(!fulfilledPromise.getReason());
       assert(!fulfilledPromise.isPending());
     }, 30);
   });
@@ -130,7 +130,7 @@ describe('synchronous-inspection-tests', function () {
     assert(!fulfilledPromise.isRejected());
 
     try {
-      fulfilledPromise.value();
+      fulfilledPromise.getValue();
 
       assert(false);
     }
@@ -142,7 +142,7 @@ describe('synchronous-inspection-tests', function () {
 
     setTimeout(function () {
       try {
-        fulfilledPromise.value();
+        fulfilledPromise.getValue();
 
         assert(false);
       }
@@ -175,7 +175,7 @@ describe('synchronous-inspection-tests', function () {
     assert(!fulfilledPromise.isRejected());
 
     try {
-      fulfilledPromise.reason();
+      fulfilledPromise.getReason();
 
       assert(false);
     }
@@ -187,7 +187,7 @@ describe('synchronous-inspection-tests', function () {
 
     setTimeout(function () {
       try {
-        fulfilledPromise.reason();
+        fulfilledPromise.getReason();
 
         assert(false);
       }
@@ -195,5 +195,13 @@ describe('synchronous-inspection-tests', function () {
         assert(true);
       }
     }, 30);
+  });
+
+  it('can disable synchronous inspection', function() {
+    Promise.enableSynchronous();
+    var testPromise = Promise.resolve('someValue');
+    assert(testPromise.getValue() == 'someValue');
+    Promise.disableSynchronous();
+    assert(testPromise.getValue == undefined);
   });
 });

--- a/test/synchronous-inspection-tests.js
+++ b/test/synchronous-inspection-tests.js
@@ -1,0 +1,199 @@
+var assert = require('better-assert');
+var Promise = require('../');
+
+describe('synchronous-inspection-tests', function () {
+  it('cannot synchronously inspect before enabling synchronous inspection', function() {
+    var finished = null;
+    var fulfilledPromise = new Promise(function(resolve, reject) {
+      setTimeout(function() {
+        resolve();
+      }, 500);
+    });
+    var rejectedPromise = new Promise(function(resolve, reject) {
+      setTimeout(function() {
+        reject();
+      }, 500);
+    });
+
+    assert(fulfilledPromise.value == undefined);
+    assert(fulfilledPromise.reason == undefined);
+    assert(fulfilledPromise.isFulfilled == undefined);
+    assert(fulfilledPromise.isPending == undefined);
+    assert(fulfilledPromise.isRejected == undefined);
+
+    assert(rejectedPromise.value == undefined);
+    assert(rejectedPromise.reason == undefined);
+    assert(rejectedPromise.isFulfilled == undefined);
+    assert(rejectedPromise.isPending == undefined);
+    assert(rejectedPromise.isRejected == undefined);
+
+    setTimeout(function() {
+      assert(fulfilledPromise.value == undefined);
+      assert(fulfilledPromise.reason == undefined);
+      assert(fulfilledPromise.isFulfilled == undefined);
+      assert(fulfilledPromise.isPending == undefined);
+      assert(fulfilledPromise.isRejected == undefined);
+
+      assert(rejectedPromise.value == undefined);
+      assert(rejectedPromise.reason == undefined);
+      assert(rejectedPromise.isFulfilled == undefined);
+      assert(rejectedPromise.isPending == undefined);
+      assert(rejectedPromise.isRejected == undefined);
+    }, 500);
+
+  });
+
+  it('can poll a promise to see if it is resolved', function () {
+    Promise.enableSynchronous();
+    var finished = null;
+    var fulfilledPromise = new Promise(function(resolve, reject) {
+      var interval = setInterval(function() {
+        if (finished !== null) {
+          clearTimeout(interval);
+
+          if (finished) {
+            resolve(true);
+          }
+          else {
+            reject(false);
+          }
+        }
+      }, 10);
+    });
+
+    assert(fulfilledPromise.isPending());
+    assert(!fulfilledPromise.isFulfilled());
+    assert(!fulfilledPromise.isRejected());
+
+    finished = true;
+
+    setTimeout(function () {
+      assert(fulfilledPromise.isFulfilled());
+      assert(!fulfilledPromise.isRejected());
+      assert(fulfilledPromise.value());
+      assert(!fulfilledPromise.isPending());
+    }, 30);
+  });
+
+  it('can poll a promise to see if it is rejected', function () {
+    Promise.enableSynchronous();
+    var finished = null;
+    var fulfilledPromise = new Promise(function(resolve, reject) {
+      var interval = setInterval(function() {
+        if (finished !== null) {
+          clearTimeout(interval);
+
+          if (finished) {
+            resolve(true);
+          }
+          else {
+            reject(false);
+          }'s'
+        }
+      }, 10);
+    });
+
+    assert(fulfilledPromise.isPending());
+    assert(!fulfilledPromise.isFulfilled());
+    assert(!fulfilledPromise.isRejected());
+
+    finished = false;
+
+    setTimeout(function () {
+      assert(!fulfilledPromise.isFulfilled());
+      assert(fulfilledPromise.isRejected());
+      assert(!fulfilledPromise.reason());
+      assert(!fulfilledPromise.isPending());
+    }, 30);
+  });
+
+  it('will throw an error if getting a value of an unfulfilled promise', function () {
+    Promise.enableSynchronous();
+    var finished = null;
+    var fulfilledPromise = new Promise(function(resolve, reject) {
+      var interval = setInterval(function() {
+        if (finished !== null) {
+          clearTimeout(interval);
+
+          if (finished) {
+            resolve(true);
+          }
+          else {
+            reject(false);
+          }
+        }
+      }, 10);
+    });
+
+    assert(fulfilledPromise.isPending());
+    assert(!fulfilledPromise.isFulfilled());
+    assert(!fulfilledPromise.isRejected());
+
+    try {
+      fulfilledPromise.value();
+
+      assert(false);
+    }
+    catch (e) {
+      assert(true);
+    }
+
+    finished = false;
+
+    setTimeout(function () {
+      try {
+        fulfilledPromise.value();
+
+        assert(false);
+      }
+      catch (e) {
+        assert(true);
+      }
+    }, 30);
+  });
+
+  it('will throw an error if getting a reason of a non-rejected promise', function () {
+    Promise.enableSynchronous();
+    var finished = null;
+    var fulfilledPromise = new Promise(function(resolve, reject) {
+      var interval = setInterval(function() {
+        if (finished !== null) {
+          clearTimeout(interval);
+
+          if (finished) {
+            resolve(true);
+          }
+          else {
+            reject(false);
+          }
+        }
+      }, 10);
+    });
+
+    assert(fulfilledPromise.isPending());
+    assert(!fulfilledPromise.isFulfilled());
+    assert(!fulfilledPromise.isRejected());
+
+    try {
+      fulfilledPromise.reason();
+
+      assert(false);
+    }
+    catch (e) {
+      assert(true);
+    }
+
+    finished = true;
+
+    setTimeout(function () {
+      try {
+        fulfilledPromise.reason();
+
+        assert(false);
+      }
+      catch (e) {
+        assert(true);
+      }
+    }, 30);
+  });
+});


### PR DESCRIPTION
Duplicates this: https://github.com/then/promise/pull/59 with a few caveats.
As per https://github.com/then/promise/pull/59#issuecomment-102028323, now only accessible after enabling, by calling `Promise.enableSynchronous()`, and can be disabled (mostly for completeness sake) by calling `Promise.disableSynchronous()`.

Is this the preferred method of getting this in, or did I misunderstand?