### PR TITLE
Add test coverage for done

### DIFF
--- a/test/extensions-tests.js
+++ b/test/extensions-tests.js
@@ -246,8 +246,22 @@ describe('extensions', function () {
     it.skip('behaves like then except for not returning anything', function () {
       //todo
     })
-    it.skip('rethrows unhandled rejections', function () {
-      //todo
+    it ('rethrows unhandled rejections', function (done) {
+      var originalTimeout = global.setTimeout
+
+      global.setTimeout = function(callback) {
+        try {
+          callback()
+        } catch (x) {
+          assert(x.message === 'It worked')
+        }
+        global.setTimeout = originalTimeout
+        done()
+      }
+
+      Promise.resolve().done(function() {
+        throw new Error('It worked')
+      })
     })
   })
   describe('promise.nodeify(callback)', function () {

--- a/test/extensions-tests.js
+++ b/test/extensions-tests.js
@@ -246,6 +246,7 @@ describe('extensions', function () {
     it.skip('behaves like then except for not returning anything', function () {
       //todo
     })
+
     it ('rethrows unhandled rejections', function (done) {
       var originalTimeout = global.setTimeout
 
@@ -254,9 +255,10 @@ describe('extensions', function () {
           callback()
         } catch (x) {
           assert(x.message === 'It worked')
+          global.setTimeout = originalTimeout
+          return done()
         }
-        global.setTimeout = originalTimeout
-        done()
+        done(new Error('Callback should have thrown an exception'))
       }
 
       Promise.resolve().done(function() {


### PR DESCRIPTION
Quite a mind bender. I was trying to test that a promise did not absorb errors when circumventing try/catch via setTimeout. I thought to look at how you all were testing this with `done`, and discovered the test was missing!

So, after killing some brain cells, I think I've got something. What do you think?