### PR TITLE
Promise states now update properly to reflect their promise chain's value

### DIFF
--- a/src/synchronous.js
+++ b/src/synchronous.js
@@ -17,7 +17,7 @@ Promise.enableSynchronous = function () {
   };
 
   Promise.prototype.getValue = function () {
-    if (this._state === 3 && this._value instanceof Promise) {
+    if (this._state === 3) {
       return this._value.getValue();
     }
 
@@ -37,7 +37,7 @@ Promise.enableSynchronous = function () {
   };
 
   Promise.prototype.getState = function () {
-    if (this._state === 3 && this._value instanceof Promise) {
+    if (this._state === 3) {
       return this._value.getState();
     }
 

--- a/src/synchronous.js
+++ b/src/synchronous.js
@@ -29,6 +29,10 @@ Promise.enableSynchronous = function () {
   };
 
   Promise.prototype.getReason = function () {
+    if (this._state === 3) {
+      return this._value.getReason();
+    }
+
     if (!this.isRejected()) {
       throw new Error('Cannot get a rejection reason of a non-rejected promise.');
     }

--- a/src/synchronous.js
+++ b/src/synchronous.js
@@ -5,18 +5,22 @@ var Promise = require('./core.js');
 module.exports = Promise;
 Promise.enableSynchronous = function () {
   Promise.prototype.isPending = function() {
-    return this._state == 0;
+    return this.getState() == 0;
   };
 
   Promise.prototype.isFulfilled = function() {
-    return this._state == 1;
+    return this.getState() == 1;
   };
 
   Promise.prototype.isRejected = function() {
-    return this._state == 2;
+    return this.getState() == 2;
   };
 
   Promise.prototype.getValue = function () {
+    if (this._state === 3 && this._value instanceof Promise) {
+      return this._value.getValue();
+    }
+
     if (!this.isFulfilled()) {
       throw new Error('Cannot get a value of an unfulfilled promise.');
     }
@@ -31,6 +35,14 @@ Promise.enableSynchronous = function () {
 
     return this._value;
   };
+
+  Promise.prototype.getState = function () {
+    if (this._state === 3 && this._value instanceof Promise) {
+      return this._value.getState();
+    }
+
+    return this._state;
+  };
 };
 
 Promise.disableSynchronous = function() {
@@ -39,4 +51,5 @@ Promise.disableSynchronous = function() {
   Promise.prototype.isRejected = undefined;
   Promise.prototype.getValue = undefined;
   Promise.prototype.getReason = undefined;
+  Promise.prototype.getState = undefined;
 };

--- a/test/synchronous-inspection-tests.js
+++ b/test/synchronous-inspection-tests.js
@@ -63,6 +63,7 @@ describe('synchronous-inspection-tests', function () {
       }, 10);
     });
 
+    assert(fulfilledPromise.getState() === 0);
     assert(fulfilledPromise.isPending());
     assert(!fulfilledPromise.isFulfilled());
     assert(!fulfilledPromise.isRejected());
@@ -70,6 +71,7 @@ describe('synchronous-inspection-tests', function () {
     finished = true;
 
     setTimeout(function () {
+      assert(fulfilledPromise.getState() === 1);
       assert(fulfilledPromise.isFulfilled());
       assert(!fulfilledPromise.isRejected());
       assert(fulfilledPromise.getValue());
@@ -97,6 +99,7 @@ describe('synchronous-inspection-tests', function () {
       }, 10);
     });
 
+    assert(fulfilledPromise.getState() === 0);
     assert(fulfilledPromise.isPending());
     assert(!fulfilledPromise.isFulfilled());
     assert(!fulfilledPromise.isRejected());
@@ -104,6 +107,7 @@ describe('synchronous-inspection-tests', function () {
     finished = false;
 
     setTimeout(function () {
+      assert(fulfilledPromise.getState() === 2);
       assert(!fulfilledPromise.isFulfilled());
       assert(fulfilledPromise.isRejected());
       assert(!fulfilledPromise.getReason());

--- a/test/synchronous-inspection-tests.js
+++ b/test/synchronous-inspection-tests.js
@@ -2,48 +2,50 @@ var assert = require('better-assert');
 var Promise = require('../');
 
 describe('synchronous-inspection-tests', function () {
-  it('cannot synchronously inspect before enabling synchronous inspection', function() {
+  it('cannot synchronously inspect before enabling synchronous inspection', function(done) {
     var finished = null;
     var fulfilledPromise = new Promise(function(resolve, reject) {
       setTimeout(function() {
         resolve();
-      }, 500);
+      }, 10);
     });
     var rejectedPromise = new Promise(function(resolve, reject) {
       setTimeout(function() {
         reject();
-      }, 500);
+      }, 10);
     });
 
-    assert(fulfilledPromise.value == undefined);
-    assert(fulfilledPromise.reason == undefined);
+    assert(fulfilledPromise.getValue == undefined);
+    assert(fulfilledPromise.getReason == undefined);
     assert(fulfilledPromise.isFulfilled == undefined);
     assert(fulfilledPromise.isPending == undefined);
     assert(fulfilledPromise.isRejected == undefined);
 
-    assert(rejectedPromise.value == undefined);
-    assert(rejectedPromise.reason == undefined);
+    assert(rejectedPromise.getValue == undefined);
+    assert(rejectedPromise.getReason == undefined);
     assert(rejectedPromise.isFulfilled == undefined);
     assert(rejectedPromise.isPending == undefined);
     assert(rejectedPromise.isRejected == undefined);
 
     setTimeout(function() {
-      assert(fulfilledPromise.value == undefined);
-      assert(fulfilledPromise.reason == undefined);
+      assert(fulfilledPromise.getValue == undefined);
+      assert(fulfilledPromise.getReason == undefined);
       assert(fulfilledPromise.isFulfilled == undefined);
       assert(fulfilledPromise.isPending == undefined);
       assert(fulfilledPromise.isRejected == undefined);
 
-      assert(rejectedPromise.value == undefined);
-      assert(rejectedPromise.reason == undefined);
+      assert(rejectedPromise.getValue == undefined);
+      assert(rejectedPromise.getReason == undefined);
       assert(rejectedPromise.isFulfilled == undefined);
       assert(rejectedPromise.isPending == undefined);
       assert(rejectedPromise.isRejected == undefined);
-    }, 500);
+
+      done()
+    }, 30);
 
   });
 
-  it('can poll a promise to see if it is resolved', function () {
+  it('can poll a promise to see if it is resolved', function (done) {
     Promise.enableSynchronous();
     var finished = null;
     var fulfilledPromise = new Promise(function(resolve, reject) {
@@ -72,10 +74,12 @@ describe('synchronous-inspection-tests', function () {
       assert(!fulfilledPromise.isRejected());
       assert(fulfilledPromise.getValue());
       assert(!fulfilledPromise.isPending());
+
+      done();
     }, 30);
   });
 
-  it('can poll a promise to see if it is rejected', function () {
+  it('can poll a promise to see if it is rejected', function (done) {
     Promise.enableSynchronous();
     var finished = null;
     var fulfilledPromise = new Promise(function(resolve, reject) {
@@ -104,10 +108,12 @@ describe('synchronous-inspection-tests', function () {
       assert(fulfilledPromise.isRejected());
       assert(!fulfilledPromise.getReason());
       assert(!fulfilledPromise.isPending());
+
+      done();
     }, 30);
   });
 
-  it('will throw an error if getting a value of an unfulfilled promise', function () {
+  it('will throw an error if getting a value of an unfulfilled promise', function (done) {
     Promise.enableSynchronous();
     var finished = null;
     var fulfilledPromise = new Promise(function(resolve, reject) {
@@ -149,10 +155,12 @@ describe('synchronous-inspection-tests', function () {
       catch (e) {
         assert(true);
       }
+
+      done();
     }, 30);
   });
 
-  it('will throw an error if getting a reason of a non-rejected promise', function () {
+  it('will throw an error if getting a reason of a non-rejected promise', function (done) {
     Promise.enableSynchronous();
     var finished = null;
     var fulfilledPromise = new Promise(function(resolve, reject) {
@@ -194,6 +202,8 @@ describe('synchronous-inspection-tests', function () {
       catch (e) {
         assert(true);
       }
+
+      done()
     }, 30);
   });
 

--- a/test/synchronous-inspection-tests.js
+++ b/test/synchronous-inspection-tests.js
@@ -218,4 +218,52 @@ describe('synchronous-inspection-tests', function () {
     Promise.disableSynchronous();
     assert(testPromise.getValue == undefined);
   });
+
+  it('can synchronously poll a resolving promise chain', function (done) {
+    Promise.enableSynchronous();
+    var fulfilledPromise = new Promise(function(resolve, reject) {
+      var interval = setTimeout(function() {
+        resolve(Promise.resolve(true));
+      }, 10);
+    });
+
+    assert(fulfilledPromise.getState() === 0);
+    assert(fulfilledPromise.isPending());
+    assert(!fulfilledPromise.isFulfilled());
+    assert(!fulfilledPromise.isRejected());
+
+    setTimeout(function() {
+      assert(fulfilledPromise.getState() === 1);
+      assert(fulfilledPromise.isFulfilled());
+      assert(!fulfilledPromise.isRejected());
+      assert(fulfilledPromise.getValue());
+      assert(!fulfilledPromise.isPending());
+
+      done();
+    }, 30);
+  });
+
+  it('can synchronously poll a rejecting promise chain', function(done) {
+    Promise.enableSynchronous();
+    var rejectedPromise = new Promise(function(resolve, reject) {
+      setTimeout(function() {
+        resolve(Promise.reject(false));
+      }, 10);
+    });
+
+    assert(rejectedPromise.getState() === 0);
+    assert(rejectedPromise.isPending());
+    assert(!rejectedPromise.isFulfilled());
+    assert(!rejectedPromise.isRejected());
+
+    setTimeout(function() {
+      assert(rejectedPromise.getState() === 2);
+      assert(!rejectedPromise.isFulfilled());
+      assert(rejectedPromise.isRejected());
+      assert(!rejectedPromise.getReason());
+      assert(!rejectedPromise.isPending());
+
+      done();
+    }, 30);
+  });
 });

--- a/test/synchronous-inspection-tests.js
+++ b/test/synchronous-inspection-tests.js
@@ -92,7 +92,7 @@ describe('synchronous-inspection-tests', function () {
           }
           else {
             reject(false);
-          }'s'
+          }
         }
       }, 10);
     });


### PR DESCRIPTION
A promise that resolves with a promise chain now properly reflects the values for isPending, isFulfilled, isRejected and getValue. Before it would assume an invalid state of `isPending: false` while being neither fulfilled nor rejected and its getValue() would point to the promise that it reflects, rather than the value of that promise.