### PR TITLE
Add standard rejection tracking

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var Promise = require('./lib/core.js');
+require('./lib/es6-extensions.js');
+require('./lib/rejection-handlers-node.js');

--- a/package.json
+++ b/package.json
@@ -31,5 +31,9 @@
   },
   "dependencies": {
     "asap": "~2.0.3"
-  }
+  },
+  "browser": {
+    "./lib/rejection-handlers-node": "./lib/rejection-handlers-client",
+    "./lib/rejection-handlers-node.js": "./lib/rejection-handlers-client.js",
+  },
 }

--- a/src/rejection-handlers-client.js
+++ b/src/rejection-handlers-client.js
@@ -1,0 +1,47 @@
+'use strict';
+
+let id = 1;
+Promise._onHandle = function (promise) {
+  if (
+    promise._state === 2 // IS REJECTED
+  ) {
+    if (promise._rejectionEmitted) {
+      if (global.onrejectionhandled) {
+        global.onrejectionhandled({promise: promise, reason: promise._value});
+      }
+      if (promise._loggingID) {
+        console.warn(
+          'Promise Rejection Handled (id: ' + promise._loggingID + '):'
+        );
+        console.warn(
+          '  This means you can ignore any previous messages of the form ' +
+          '"Possible Unhandled Promise Rejection" with id ' +
+          promise._loggingID + '.'
+        );
+      }
+    } else {
+      clearTimeout(promise._rejectionEmitTimer);
+    }
+  }
+};
+Promise._onReject = function (promise, err) {
+  if (promise._deferredState === 0) { // not yet handled
+    promise._rejectionEmitTimer = setTimeout(function () {
+      promise._rejectionEmitted = true;
+      if (global.onunhandledrejection) {
+        global.onunhandledrejection({promise: promise, reason: err});
+      } else  {
+        promise._loggingID = id++;
+        console.warn(
+          'Possible Unhandled Promise Rejection (id: ' +
+          promise._loggingID +
+          '):'
+        );
+        var errStr = (error && (error.stack || error)) + '';
+        errStr.split('\n').forEach(function (line) {
+          console.warn('  ' + line);
+        });
+      }
+    }, 0);
+  }
+};

--- a/src/rejection-handlers-node.js
+++ b/src/rejection-handlers-node.js
@@ -1,0 +1,47 @@
+'use strict';
+
+let id = 1;
+Promise._onHandle = function (promise) {
+  if (
+    promise._state === 2 // IS REJECTED
+  ) {
+    if (promise._rejectionEmitted) {
+      promise.emit('rejectionHandled', promise);
+      if (promise._loggingID) {
+        console.warn(
+          'Promise Rejection Handled (id: ' + promise._loggingID + '):'
+        );
+        console.warn(
+          '  This means you can ignore any previous messages of the form ' +
+          '"Possible Unhandled Promise Rejection" with id ' +
+          promise._loggingID + '.'
+        );
+      }
+    } else {
+      clearTimeout(promise._rejectionEmitTimer);
+    }
+  }
+};
+Promise._onReject = function (promise, err) {
+  if (promise._deferredState === 0) { // not yet handled
+    promise._rejectionEmitTimer = setTimeout(function () {
+      promise._rejectionEmitted = true;
+      process.emit('unhandledRejection', promise, err);
+      if (
+        process.listenerCount &&
+        process.listenerCount('unhandledRejection') === 0
+      ) {
+        promise._loggingID = id++;
+        console.warn(
+          'Possible Unhandled Promise Rejection (id: ' +
+          promise._loggingID +
+          '):'
+        );
+        var errStr = (error && (error.stack || error)) + '';
+        errStr.split('\n').forEach(function (line) {
+          console.warn('  ' + line);
+        });
+      }
+    }, 0);
+  }
+};


### PR DESCRIPTION
Standards seem to have formed around rejection tracking in node and the browser.  This aims to provide a polyfill with them enabled.  In keeping with being a true polyfill, it provides a version without .done as the result of `require('promise/es6')`.  The default export for users who run `require('promise')` remains un-changed, but I think it's worth encouraging people to use this module when they require a true polyfill.