### PR TITLE
Add files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,7 @@ test
 .travis.yml
 component.json
 coverage
+.jshintrc
+.npmignore
+/build.js
+src/


### PR DESCRIPTION
Publish only essential files.
This will speed up npm installs that include this package.
