### PR TITLE
Update asap dependency to fix issues in react native env

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "rimraf": "^2.3.2"
   },
   "dependencies": {
-    "asap": "~2.0.3"
+    "asap": "~2.0.6"
   }
 }


### PR DESCRIPTION
See https://github.com/kriskowal/asap/pull/72 for details on the main issue.
This PR updates the version dependency on asap to `2.0.6` to fix the issue linked above.