### PR TITLE
For better code specifications

### DIFF
--- a/src/finally.js
+++ b/src/finally.js
@@ -3,7 +3,7 @@
 var Promise = require('./core.js');
 
 module.exports = Promise;
-Promise.prototype['finally'] = function (f) {
+Promise.prototype.finally = function (f) {
   return this.then(function (value) {
     return Promise.resolve(f()).then(function () {
       return value;


### PR DESCRIPTION
There is no need to use `Promise.prototype['finally']`