### PR TITLE
Make the build reproducible

### DIFF
--- a/build.js
+++ b/build.js
@@ -5,16 +5,12 @@ var rimraf = require('rimraf');
 var acorn = require('acorn');
 var walk = require('acorn/dist/walk');
 
-var ids = [];
+var idx = process.env.SOURCE_DATE_EPOCH || parseInt(Math.random() * 1000, 10);
 var names = {};
 
 function getIdFor(name) {
   if (name in names) return names[name];
-  var id;
-  do {
-    id = '_' + Math.floor(Math.random() * 100);
-  } while (ids.indexOf(id) !== -1)
-  ids.push(id);
+  var id = '_' + idx++;
   names[name] = id;
   return id;
 }


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that node-promise could not be built reproducibly as it uses
random numbers as throwaway identifiers.

This patch uses determinstic numbers instead.

This was filed in @Debian as https://bugs.debian.org/886277

 [0] https://reproducible-builds.org/

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>