### PR TITLE
Make the build reproducible

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,19 +4,19 @@ var fs = require('fs');
 var rimraf = require('rimraf');
 var acorn = require('acorn');
 var walk = require('acorn/dist/walk');
+var crypto = require('crypto');
 
-var ids = [];
-var names = {};
+var shasum = crypto.createHash('sha512');
+fs.readdirSync(__dirname + '/src').sort().forEach(function (filename) {
+  shasum.update(fs.readFileSync(__dirname + '/src/' + filename, 'utf8'));
+});
 
+const names = {};
+const characterSet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+let i = characterSet.indexOf(shasum.digest('base64').replace(/[^0-9a-zA-Z]/g, '')[0]);
 function getIdFor(name) {
-  if (name in names) return names[name];
-  var id;
-  do {
-    id = '_' + Math.floor(Math.random() * 100);
-  } while (ids.indexOf(id) !== -1)
-  ids.push(id);
-  names[name] = id;
-  return id;
+  if (names[name]) return names[name];
+  return names[name] = '_' + characterSet[i++ % characterSet.length]
 }
 
 function fixup(src) {


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that node-promise could not be built reproducibly as it uses
random numbers as throwaway identifiers.

This patch uses a determinstic suffix for these identifiers based
on the contents of the src/ directory.

This was filed in @Debian as https://bugs.debian.org/886277. There was
also a previous aborted attempt in #146.

 [0] https://reproducible-builds.org/
 [1] https://github.com/then/promise/pull/146

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>