### PR TITLE
feat: support ES2015 iterables in all() and race()

### DIFF
--- a/src/es6-extensions.js
+++ b/src/es6-extensions.js
@@ -46,8 +46,20 @@ Promise.resolve = function (value) {
   return valuePromise(value);
 };
 
+var iterableToArray = function (iterable) {
+  if (typeof Array.from === 'function') {
+    // ES2015+, iterables exist
+    iterableToArray = Array.from;
+    return Array.from(iterable);
+  }
+
+  // ES5, only arrays and array-likes exist
+  iterableToArray = function (x) { return x; };
+  return iterable;
+}
+
 Promise.all = function (arr) {
-  var args = Array.prototype.slice.call(arr);
+  var args = Array.prototype.slice.call(iterableToArray(arr));
 
   return new Promise(function (resolve, reject) {
     if (args.length === 0) return resolve([]);
@@ -94,7 +106,7 @@ Promise.reject = function (value) {
 
 Promise.race = function (values) {
   return new Promise(function (resolve, reject) {
-    values.forEach(function(value){
+    iterableToArray(values).forEach(function(value){
       Promise.resolve(value).then(resolve, reject);
     });
   });

--- a/src/es6-extensions.js
+++ b/src/es6-extensions.js
@@ -54,12 +54,12 @@ var iterableToArray = function (iterable) {
   }
 
   // ES5, only arrays and array-likes exist
-  iterableToArray = function (x) { return x; };
-  return iterable;
+  iterableToArray = function (x) { return Array.prototype.slice.call(x); };
+  return Array.prototype.slice.call(iterable);
 }
 
 Promise.all = function (arr) {
-  var args = Array.prototype.slice.call(iterableToArray(arr));
+  var args = iterableToArray(arr);
 
   return new Promise(function (resolve, reject) {
     if (args.length === 0) return resolve([]);

--- a/test/extensions-tests.js
+++ b/test/extensions-tests.js
@@ -240,6 +240,116 @@ describe('extensions', function () {
         });
       });
     })
+
+    describe('a Set', function () {
+      describe('that is empty', function () {
+        it('returns a promise for an empty array', function (done) {
+          var res = Promise.all(new Set([]))
+          assert(res instanceof Promise)
+          res.then(function (res) {
+            assert(Array.isArray(res))
+            assert(res.length === 0)
+          })
+          .nodeify(done)
+        })
+      })
+      describe('of objects', function () {
+        it('returns a promise for the array', function (done) {
+          var res = Promise.all(new Set([a, b, c]))
+          assert(res instanceof Promise)
+          res.then(function (res) {
+            assert(Array.isArray(res))
+            assert(res[0] === a)
+            assert(res[1] === b)
+            assert(res[2] === c)
+          })
+          .nodeify(done)
+        })
+      })
+      describe('of promises', function () {
+        it('returns a promise for an array containing the fulfilled values', function (done) {
+          var d = {}
+          var resolveD
+          var res = Promise.all(new Set([A, B, C, new Promise(function (resolve) { resolveD = resolve })]))
+          assert(res instanceof Promise)
+          res.then(function (res) {
+            assert(Array.isArray(res))
+            assert(res[0] === a)
+            assert(res[1] === b)
+            assert(res[2] === c)
+            assert(res[3] === d)
+          })
+          .nodeify(done)
+          resolveD(d)
+        })
+      })
+      describe('of mixed values', function () {
+        it('returns a promise for an array containing the fulfilled values', function (done) {
+          var res = Promise.all(new Set([A, b, C]))
+          assert(res instanceof Promise)
+          res.then(function (res) {
+            assert(Array.isArray(res))
+            assert(res[0] === a)
+            assert(res[1] === b)
+            assert(res[2] === c)
+          })
+          .nodeify(done)
+        })
+      })
+      describe('containing at least one rejected promise', function () {
+        it('rejects the resulting promise', function (done) {
+          var res = Promise.all(new Set([A, rejected, C]))
+          assert(res instanceof Promise)
+          res.then(function (res) {
+            throw new Error('Should be rejected')
+          },
+          function (err) {
+            assert(err === rejection)
+          })
+          .nodeify(done)
+        })
+      })
+      describe('containing at least one eventually rejected promise', function () {
+        it('rejects the resulting promise', function (done) {
+          var rejectB
+          var rejected = new Promise(function (resolve, reject) { rejectB = reject })
+          var res = Promise.all(new Set([A, rejected, C]))
+          assert(res instanceof Promise)
+          res.then(function (res) {
+            throw new Error('Should be rejected')
+          },
+          function (err) {
+            assert(err === rejection)
+          })
+          .nodeify(done)
+          rejectB(rejection)
+        })
+      })
+      describe('with a promise that resolves twice', function () {
+        it('still waits for all the other promises', function (done) {
+          var fakePromise = {then: function (onFulfilled) { onFulfilled(1); onFulfilled(2) }}
+          var eventuallyRejected = {then: function (_, onRejected) { this.onRejected = onRejected }}
+          var res = Promise.all(new Set([fakePromise, eventuallyRejected]))
+          assert(res instanceof Promise)
+          res.then(function (res) {
+            throw new Error('Should be rejected')
+          },
+          function (err) {
+            assert(err === rejection)
+          })
+          .nodeify(done)
+          eventuallyRejected.onRejected(rejection);
+        })
+      })
+      describe('when given a foreign promise', function () {
+        it('should provide the correct value of `this`', function (done) {
+          var p = {then: function (onFulfilled) { onFulfilled({self: this}); }};
+          Promise.all(new Set([p])).then(function (results) {
+            assert(p === results[0].self);
+          }).nodeify(done);
+        });
+      });
+    })
   })
 
   describe('promise.done(onFulfilled, onRejected)', function () {


### PR DESCRIPTION
Aligns `Promise.all()` and `Promise.race()` with the spec by supporting iterables as arguments. This is done by basically feature-detecting ES2015 and keeping the current behaviour in ES5 environments (which I assume are still intended to be supported).

- [x] The Flow types shipped with `promise` already refer to iterables rather than arrays, so don't need to be updated.
- [x] The official TypeScript definitions for Promise are [silent on iterables for `all()`](https://github.com/microsoft/TypeScript/blob/26184f0ec825e4438a6cafd86758596c6999f565/lib/lib.es2015.promise.d.ts#L35-L113) so nothing needs to be done for it here.
- [ ] The official TypeScript definitions for Promise do have an [iterable overload of `race()`](https://github.com/microsoft/TypeScript/blob/26184f0ec825e4438a6cafd86758596c6999f565/lib/lib.es2015.promise.d.ts#L115-L129) but the types (where they do overlap) are not exactly what `promise` ships. I don't use TypeScript so I'm not sure what is desired here, and wouldn't be able to test my changes. We could choose to leave the types as they are for now.

cc @cpojer 