### PR TITLE
fix: add missing `return` after reject in Promise.all for already-rejected promises

### DIFF
--- a/src/es6-extensions.js
+++ b/src/es6-extensions.js
@@ -71,7 +71,7 @@ Promise.all = function (arr) {
             val = val._value;
           }
           if (val._state === 1) return res(i, val._value);
-          if (val._state === 2) reject(val._value);
+          if (val._state === 2) return reject(val._value);
           val.then(function (val) {
             res(i, val);
           }, reject);

--- a/test/extensions-tests.js
+++ b/test/extensions-tests.js
@@ -525,6 +525,31 @@ describe('extensions', function () {
           .nodeify(done)
         })
       })
+      describe('containing an already-rejected promise', function () {
+        it('does not attach a .then handler to the rejected promise', function (done) {
+          var rejectedPromise = new Promise(function (resolve, reject) { reject(rejection) })
+          var origThen = Promise.prototype.then
+          var thenCallsOnRejected = 0
+
+          Promise.prototype.then = function () {
+            if (this === rejectedPromise) thenCallsOnRejected++
+            return origThen.apply(this, arguments)
+          }
+
+          var result = Promise.all([A, rejectedPromise])
+          Promise.prototype.then = origThen
+
+          result.then(
+            function () {
+              throw new Error('Should be rejected')
+            },
+            function (err) {
+              assert(err === rejection)
+              assert(thenCallsOnRejected === 0)
+            }
+          ).nodeify(done)
+        })
+      })
       describe('containing at least one eventually rejected promise', function () {
         it('rejects the resulting promise', function (done) {
           var rejectB


### PR DESCRIPTION
When an already-rejected promise (state === 2) was passed to Promise.all, reject(val._value) was called but execution fell through to val.then(...), attaching an unnecessary handler to the already-rejected promise. This is inconsistent with the return pattern used for fulfilled promises (state === 1) on the preceding line. While the doResolve 'done' guard prevented incorrect behavior, the missing return wasted resources by scheduling an extra asynchronous handler invocation.