### PR TITLE
fix: order Promise.any() rejection reasons by input index

### DIFF
--- a/src/es6-extensions.js
+++ b/src/es6-extensions.js
@@ -158,7 +158,8 @@ Promise.any = function promiseAny(values) {
   return new Promise(function(resolve, reject) {
     var promises = iterableToArray(values);
     var hasResolved = false;
-    var rejectionReasons = [];
+    var rejectionReasons = new Array(promises.length);
+    var rejectionCount = 0;
 
     function resolveOnce(value) {
       if (!hasResolved) {
@@ -167,10 +168,11 @@ Promise.any = function promiseAny(values) {
       }
     }
 
-    function rejectionCheck(reason) {
-      rejectionReasons.push(reason);
+    function rejectionCheck(i, reason) {
+      rejectionReasons[i] = reason;
+      rejectionCount++;
 
-      if (rejectionReasons.length === promises.length) {
+      if (rejectionCount === promises.length) {
         reject(getAggregateError(rejectionReasons));
       }
     }
@@ -178,8 +180,10 @@ Promise.any = function promiseAny(values) {
     if(promises.length === 0){
       reject(getAggregateError(rejectionReasons));
     } else {
-      promises.forEach(function(value){
-        Promise.resolve(value).then(resolveOnce, rejectionCheck);
+      promises.forEach(function(value, i){
+        Promise.resolve(value).then(resolveOnce, function(reason) {
+          rejectionCheck(i, reason);
+        });
       });
     }
   });

--- a/test/extensions-tests.js
+++ b/test/extensions-tests.js
@@ -198,6 +198,27 @@ describe('extensions', function () {
           }).nodeify(done);
         });
       });
+      describe('containing all rejected promises rejecting out of order', function () {
+        it('orders errors by input index, not completion order', function (done) {
+          var rejectFirst, rejectSecond, rejectThird;
+          var p0 = new Promise(function (resolve, reject) { rejectFirst = reject; });
+          var p1 = new Promise(function (resolve, reject) { rejectSecond = reject; });
+          var p2 = new Promise(function (resolve, reject) { rejectThird = reject; });
+          var e0 = { order: 0 };
+          var e1 = { order: 1 };
+          var e2 = { order: 2 };
+          var res = Promise.any([p0, p1, p2]);
+          // reject in reverse order: p2 first, then p1, then p0
+          rejectThird(e2);
+          rejectSecond(e1);
+          rejectFirst(e0);
+          res.catch(function (err) {
+            assert(err.errors[0] === e0);
+            assert(err.errors[1] === e1);
+            assert(err.errors[2] === e2);
+          }).nodeify(done);
+        });
+      });
     })
   })
   describe('Promise.allSettled(...)', function () {


### PR DESCRIPTION
Promise.any() collected rejection reasons using push(), which stored them in completion order rather than input index order. The ES2021 spec requires AggregateError.errors to be ordered by the input promise index. Use index-based assignment and a separate counter instead, matching the approach used by Promise.all().

Fixes: https://github.com/then/promise/issues/181